### PR TITLE
Ability to Set Proxied for the DNS Records

### DIFF
--- a/lib/glare.rb
+++ b/lib/glare.rb
@@ -10,9 +10,9 @@ require 'glare/errors'
 
 module Glare
   class << self
-    def register(fqdn, destination, type)
+    def register(fqdn, destination, type, proxied = false)
       client = build_client
-      Domain.new(client).register(fqdn, destination, type)
+      Domain.new(client).register(fqdn, destination, type, proxied)
     end
 
     def resolve(fqdn, type)

--- a/lib/glare/dns_record.rb
+++ b/lib/glare/dns_record.rb
@@ -2,26 +2,29 @@ module Glare
   class DnsRecord
     include Comparable
 
-    def initialize(name:, type:, content:)
+    def initialize(name:, type:, content:, proxied:)
       @name = name
       @type = type
       @content = content
+      @proxied = proxied
     end
 
     def to_h
       {
         type: @type,
         name: @name,
-        content: @content
+        content: @content,
+        proxied: @proxied
       }
     end
 
     def <=>(dns_record)
       @type <=> dns_record.type &&
         @name <=> dns_record.name &&
-        @content <=> dns_record.content
+        @content <=> dns_record.content &&
+        @proxied <=> dns_record.proxied
     end
 
-    attr_reader :content, :type, :name
+    attr_reader :content, :type, :name, :proxied
   end
 end

--- a/lib/glare/domain.rb
+++ b/lib/glare/domain.rb
@@ -7,9 +7,9 @@ module Glare
       @client = client
     end
 
-    def register(fqdn, destinations, type)
+    def register(fqdn, destinations, type, proxied = false)
       dns_records = Array(destinations).map do |destination|
-        DnsRecord.new(type: type, name: fqdn, content: destination)
+        DnsRecord.new(type: type, name: fqdn, content: destination, proxied: proxied)
       end
 
       zone = Zone.new(@client, fqdn)

--- a/lib/glare/domain/record.rb
+++ b/lib/glare/domain/record.rb
@@ -2,12 +2,12 @@ module Glare
   class Domain
     class Record
       class << self
-        def register(client, zone, dns_records)
+        def register(client, zone, dns_records, proxied = false)
           @client = client
           existing_records = zone.records(dns_records.first.type)
           zone_id = zone.id
 
-          update(zone_id, dns_records, existing_records)
+          update(zone_id, dns_records, existing_records, proxied)
         end
 
         def deregister(client, zone, dns_records)

--- a/lib/glare/domain/record.rb
+++ b/lib/glare/domain/record.rb
@@ -7,7 +7,7 @@ module Glare
           existing_records = zone.records(dns_records.first.type)
           zone_id = zone.id
 
-          update(zone_id, dns_records, existing_records, proxied)
+          update(zone_id, dns_records, existing_records)
         end
 
         def deregister(client, zone, dns_records)


### PR DESCRIPTION
I have changed the Register DNS function to take into account the **_proxied_** value as in the API Docs for Cloudflare V4: https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record

The default value is **_false_**

This allows the user to set this option: https://www.evernote.com/l/ACG89DKViupBHrVANIEUOdpateaKQj8lKb4